### PR TITLE
Change CCL Dependency

### DIFF
--- a/src/ccl/ascend/infiniccl_ascend.h
+++ b/src/ccl/ascend/infiniccl_ascend.h
@@ -2,7 +2,7 @@
 #define INFINICCL_ASCEND_H_
 #include "infiniccl.h"
 
-#ifdef ENABLE_ASCEND_NPU
+#if defined(ENABLE_ASCEND_NPU) && defined (ENABLE_CCL)
 #define IMPL_WITH_ASCEND ;
 #else
 #define IMPL_WITH_ASCEND { return INFINICCL_STATUS_DEVICE_NOT_SUPPORTED; }

--- a/src/ccl/cambricon/infiniccl_cambricon.h
+++ b/src/ccl/cambricon/infiniccl_cambricon.h
@@ -2,7 +2,7 @@
 #define INFINICCL_CAMBRICON_H_
 #include "infiniccl.h"
 
-#ifdef ENABLE_CAMBRICON_MLU
+#if defined(ENABLE_CAMBRICON_MLU) && defined(ENABLE_CCL)
 #define IMPL_WITH_CAMBRICON ;
 #else
 #define IMPL_WITH_CAMBRICON { return INFINICCL_STATUS_DEVICE_NOT_SUPPORTED; }

--- a/src/ccl/cuda/infiniccl_cuda.h
+++ b/src/ccl/cuda/infiniccl_cuda.h
@@ -2,7 +2,7 @@
 #define INFINICCL_CUDA_H_
 #include "infiniccl.h"
 
-#ifdef ENABLE_NV_GPU
+#if defined(ENABLE_NV_GPU) && defined(ENABLE_CCL)
 #define IMPL_WITH_CUDA ;
 #else
 #define IMPL_WITH_CUDA { return INFINICCL_STATUS_DEVICE_NOT_SUPPORTED; }

--- a/src/ccl/maca/infiniccl_maca.h
+++ b/src/ccl/maca/infiniccl_maca.h
@@ -2,7 +2,7 @@
 #define INFINICCL_MACA_H_
 #include "infiniccl.h"
 
-#ifdef ENABLE_METAX_GPU
+#if defined(ENABLE_METAX_GPU) && defined(ENABLE_CCL)
 #define IMPL_WITH_MACA ;
 #else
 #define IMPL_WITH_MACA { return INFINICCL_STATUS_DEVICE_NOT_SUPPORTED; }

--- a/xmake.lua
+++ b/xmake.lua
@@ -40,6 +40,7 @@ option("ccl")
     set_default(true)
     set_showmenu(true)
     set_description("Enable or disable multi-device communication support")
+    add_defines("ENABLE_CCL")
 option_end()
 
 option("infer")
@@ -191,7 +192,6 @@ target("infinirt")
     add_installfiles("include/infinirt.h", {prefixdir = "include"})
 target_end()
 
-if has_config("ccl") then
 target("infiniccl")
     set_kind("shared")
     add_deps("infinirt")
@@ -212,7 +212,6 @@ target("infiniccl")
     set_installdir(infini_root)
     add_installfiles("include/infiniccl.h", {prefixdir = "include"})
 target_end()
-end
 
 if has_config("infer") then
 target("infiniinfer")


### PR DESCRIPTION
 - Infiniccl will now always be compiled and distributed 
 - The implementation of Infiniccl functions for CUDA will directly return unsupported status if either nv-gpu or ccl is not enabled 